### PR TITLE
Reduced dependencies

### DIFF
--- a/src/ThingsMobile/IServiceCollectionExtensions.cs
+++ b/src/ThingsMobile/IServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using System;
 using System.Net.Http;
 using ThingsMobile;
@@ -16,53 +15,19 @@ namespace Microsoft.Extensions.DependencyInjection
         /// related services to the <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-        /// <param name="configuration">A configuration object with values for a <see cref="ThingsMobileClientOptions"/>.</param>
-        /// <param name="configureOptions">A delegate that is used to configure a <see cref="ThingsMobileClientOptions"/>.</param>
+        /// <param name="configure">A delegate that is used to configure a <see cref="ThingsMobileClientOptions"/>.</param>
         /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
         public static IHttpClientBuilder AddThingsMobile(this IServiceCollection services,
-                                                         IConfiguration? configuration = null,
-                                                         Action<ThingsMobileClientOptions>? configureOptions = null)
+                                                         Action<ThingsMobileClientOptions>? configure = null)
         {
-            // if we have a configuration, add it
-            if (configuration != null)
+            if (configure != null)
             {
-                services.Configure<ThingsMobileClientOptions>(configuration);
-            }
-
-            // if we have a configuration action, add it
-            if (configureOptions != null)
-            {
-                services.Configure(configureOptions);
+                services.Configure(configure);
             }
 
             services.AddSingleton<IValidateOptions<ThingsMobileClientOptions>, ThingsMobileClientValidateOptions>();
 
             return services.AddHttpClient<ThingsMobileClient>();
-        }
-
-        /// <summary>
-        /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ThingsMobileClient"/> and
-        /// related services to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-        /// <param name="configureOptions">A delegate that is used to configure a <see cref="ThingsMobileClientOptions"/>.</param>
-        /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-        public static IHttpClientBuilder AddThingsMobile(this IServiceCollection services,
-                                                         Action<ThingsMobileClientOptions> configureOptions)
-        {
-            return services.AddThingsMobile(null, configureOptions);
-        }
-
-        /// <summary>
-        /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ThingsMobileClient"/> and
-        /// related services to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-        /// <param name="configuration">A configuration object with values for a <see cref="ThingsMobileClientOptions"/>.</param>
-        /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-        public static IHttpClientBuilder AddThingsMobile(this IServiceCollection services, IConfiguration configuration)
-        {
-            return services.AddThingsMobile(configuration, null);
         }
 
         /// <summary>

--- a/src/ThingsMobile/ThingsMobile.csproj
+++ b/src/ThingsMobile/ThingsMobile.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Remove overloads that take in `IConfiguraation` instances and instead leave that to the implementor. Hence replace `Microsoft.Extensions.Options.ConfigurationExtensions` reference with `Microsoft.Extensions.Options`.