### PR TITLE
Updates for 2021 November 24

### DIFF
--- a/src/ThingsMobile/Models/BasicResponse.cs
+++ b/src/ThingsMobile/Models/BasicResponse.cs
@@ -1,0 +1,15 @@
+﻿using System.Xml.Serialization;
+
+namespace ThingsMobile.Models;
+
+/// <summary>
+/// Basic response
+/// </summary>
+[Serializable]
+[XmlRoot("result")]
+public class BasicResponse : BaseResponseModel
+{
+    ///
+    [XmlElement("message")]
+    public string? Message { get; set; }
+}

--- a/src/ThingsMobile/Models/CallDetailRecord.cs
+++ b/src/ThingsMobile/Models/CallDetailRecord.cs
@@ -45,10 +45,22 @@ public class CallDetailRecord
     public string? Imsi { get; set; }
 
     /// <summary>
+    /// MSISDN of the user
+    /// </summary>
+    [XmlElement(ElementName = "cdrMsisdn")]
+    public string? Msisdn { get; set; }
+
+    /// <summary>
     /// Network used
     /// </summary>
     [XmlElement(ElementName = "cdrNetwork")]
     public string? Network { get; set; }
+
+    /// <summary>
+    /// Operator used
+    /// </summary>
+    [XmlElement(ElementName = "cdrOperator")]
+    public string? Operator { get; set; }
 
     /// <summary>
     /// Traffic in bytes

--- a/src/ThingsMobile/Models/CdrPaginated.cs
+++ b/src/ThingsMobile/Models/CdrPaginated.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml.Serialization;
+
+namespace ThingsMobile.Models;
+
+/// <summary>
+/// A collection of CDRs
+/// </summary>
+[Serializable]
+[XmlRoot("result")]
+public class CdrPaginated : BaseResponseModel
+{
+    /// <summary>
+    /// Call detail records
+    /// </summary>
+    [XmlArray("cdrsPaginated")]
+    [XmlArrayItem("cdrPaginated", typeof(CallDetailRecord))]
+    public CallDetailRecord[]? CallDetailRecords { get; set; }
+}

--- a/src/ThingsMobile/ThingsMobileClient.cs
+++ b/src/ThingsMobile/ThingsMobileClient.cs
@@ -423,6 +423,36 @@ public class ThingsMobileClient
         return await PostAsync<BasicResponse>("/services/business-api/downloadCdr", parameters, cancellationToken);
     }
 
+    /// <summary>
+    /// Get paginated CDRs for the selected SIM in the time range.
+    /// </summary>
+    /// <param name="msisdnList">Sim numbers</param>
+    /// <param name="start">Start date of the range</param>
+    /// <param name="end">End date of the range</param>
+    /// <param name="page">page number for SIM's CDR</param>
+    /// <param name="pageSize">CDR number per page</param>
+    /// <param name="cancellationToken">The token for cancelling the task</param>
+    /// <returns></returns>
+    public async Task<ThingsMobileResponse<CdrPaginated>> GetCdrAsync(List<string> msisdnList,
+                                                                      DateTimeOffset? start = null,
+                                                                      DateTimeOffset? end = null,
+                                                                      int? page = null,
+                                                                      int? pageSize = null,
+                                                                      CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string?>
+        {
+            ["msisdnList"] = string.Join(",", msisdnList),
+        };
+
+        if (start is not null) parameters["startDateRange"] = start.Value.ToString("yyyy-MM-dd HH:mm:ss");
+        if (end is not null) parameters["endDateRange"] = end.Value.ToString("yyyy-MM-dd HH:mm:ss");
+        if (page is not null) parameters["page"] = page.Value.ToString();
+        if (pageSize is not null) parameters["pageSize"] = Math.Min(pageSize.Value, 500).ToString();
+
+        return await PostAsync<CdrPaginated>("/services/business-api/getCdrPaginated", parameters, cancellationToken);
+    }
+
     private async Task<ThingsMobileResponse<T>> PostAsync<T>(string path, Dictionary<string, string?>? parameters = null, CancellationToken cancellationToken = default)
         where T : BaseResponseModel
     {

--- a/src/ThingsMobile/ThingsMobileClient.cs
+++ b/src/ThingsMobile/ThingsMobileClient.cs
@@ -398,6 +398,31 @@ public class ThingsMobileClient
         return await PostAsync<BaseResponseModel>("/services/business-api/rechargeSim", parameters, cancellationToken);
     }
 
+    /// <summary>
+    /// Asynchronous export of CDR for the selected SIM in the time range.
+    /// The result is send via email.
+    /// </summary>
+    /// <param name="msisdnList">Sim numbers</param>
+    /// <param name="start">Start date of the range</param>
+    /// <param name="end">End date of the range</param>
+    /// <param name="cancellationToken">The token for cancelling the task</param>
+    /// <returns></returns>
+    public async Task<ThingsMobileResponse<BasicResponse>> DownloadCdrAsync(List<string> msisdnList,
+                                                                            DateTimeOffset? start = null,
+                                                                            DateTimeOffset? end = null,
+                                                                            CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, string?>
+        {
+            ["msisdnList"] = string.Join(",", msisdnList),
+        };
+
+        if (start is not null) parameters["startDateRange"] = start.Value.ToString("yyyy-MM-dd HH:mm:ss");
+        if (end is not null) parameters["endDateRange"] = end.Value.ToString("yyyy-MM-dd HH:mm:ss");
+
+        return await PostAsync<BasicResponse>("/services/business-api/downloadCdr", parameters, cancellationToken);
+    }
+
     private async Task<ThingsMobileResponse<T>> PostAsync<T>(string path, Dictionary<string, string?>? parameters = null, CancellationToken cancellationToken = default)
         where T : BaseResponseModel
     {

--- a/src/ThingsMobile/ThingsMobileClientOptions.cs
+++ b/src/ThingsMobile/ThingsMobileClientOptions.cs
@@ -21,4 +21,13 @@ public class ThingsMobileClientOptions
     /// For test purposes, set this value to <c>https://test.thingsmobile.com/</c>
     /// </summary>
     public Uri Endpoint { get; set; } = new Uri("https://api.thingsmobile.com/");
+
+    /// <summary>Use credentials and endpoint for the test environment.</summary>
+    /// <remarks>See docs for test SIMs</remarks>
+    public void UseTestEnvironment()
+    {
+        Username = "test";
+        Token = "Thingsmobil3";
+        Endpoint = new Uri("https://test.thingsmobile.com/");
+    }
 }

--- a/tests/ThingsMobile.Tests/Samples/cdrPaginatedResponse.xml
+++ b/tests/ThingsMobile.Tests/Samples/cdrPaginatedResponse.xml
@@ -1,0 +1,14 @@
+﻿<result>
+	<cdrsPaginated>
+		<cdrPaginated>
+			<cdrCountry>ESP</cdrCountry>
+			<cdrDateStart>2020-10-05 19:11:48</cdrDateStart>
+			<cdrDateStop>2020-10-05 19:21:48</cdrDateStop>
+			<cdrMsisdn>882360001975037</cdrMsisdn>
+			<cdrNetwork>Zone 1</cdrNetwork>
+			<cdrOperator>ESPVV</cdrOperator>
+			<cdrTraffic>1000000</cdrTraffic>
+		</cdrPaginated>
+	</cdrsPaginated>
+	<done>true</done>
+</result>

--- a/tests/ThingsMobile.Tests/TestSamples.cs
+++ b/tests/ThingsMobile.Tests/TestSamples.cs
@@ -12,4 +12,5 @@ internal static class TestSamples
 
     public static Task<string> GetErrorAsync() => GetSampleResourceAsStringAsync("error.xml");
     public static Task<string> GetSimListResponseAsync() => GetSampleResourceAsStringAsync("simListResponse.xml");
+    public static Task<string> GetCdrPaginatedResponseAsync() => GetSampleResourceAsStringAsync("cdrPaginatedResponse.xml");
 }

--- a/tests/ThingsMobile.Tests/ThingsMobile.Tests.csproj
+++ b/tests/ThingsMobile.Tests/ThingsMobile.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Samples\error.xml" />
+    <EmbeddedResource Include="Samples\cdrPaginatedResponse.xml" />
     <EmbeddedResource Include="Samples\simListResponse.xml" />
   </ItemGroup>
 


### PR DESCRIPTION
- Support test credentials and endpoint in `ThingsMobileClientOptions`.
- Added support for `getCdrPaginated` and `downloadCdr` APIs.
- Added `cdrOperator` and `cdrMsisdn` to `CallDetailRecord`